### PR TITLE
Add docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,5 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# MacOS .DS_Store
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,16 @@
 # Use an official Python runtime as a parent image
-FROM python:3.6-stretch
+FROM python:latest
 
-MAINTAINER  Shirish Kadam <shirishkadam35@gmail.com>
+LABEL maintainer="ziggerzz@gmail.com"
 
-# Set the working directory to /app
+# Set working directory
 WORKDIR /adam_qas
 
-# Copy the current directory contents into the container at /app
-COPY . /adam_qas
+# First copy and install the requirements so further cache can be used
+COPY ./requirements.txt ./requirements.txt
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --default-timeout=3000 --trusted-host pypi.python.org -r requirements.txt
 
-# Install Elasticsearch
-ENV ELASTICSEARCH_VER 7.1.1
-RUN wget "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VER}-amd64.deb"
-RUN dpkg -i --force-confnew elasticsearch-${ELASTICSEARCH_VER}-amd64.deb
-# RUN until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
-
-
-# Make port 80 available to the world outside this container
-EXPOSE 80 9200
-
-# Define environment variable
-ENV VERSION 1
-
-# Run app when the container launches
-CMD ["python", "-m", "qas.adam", "-v"]
+# Copy the current directory contents into the container at /app
+COPY . /adam_qas

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ _Note:_ The above installation downloads the best-matching default english langu
 ```bash
 $ python -m spacy download en_core_web_md
 ```
+
+## Running with Docker
+
+```bash
+$ git clone https://github.com/5hirish/adam_qas.git
+$ cd adam_qas
+$ docker-compose up
+```
+
+Now both conntainers are up and running.
+Next step is to enter in the python container and run Adam:
+
+```bash
+$ docker exec -it $(docker ps -a -q  --filter ancestor=adam_qas_adam) bash
+$ python -m qas.adam -vv "When was linux kernel version 4.0 released ?"
+```
+
+
 ## References
 
 Find more in depth documentation about the system with its research paper and system architecture [here](docs/ARCHI.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.1.1
+    #container_name: es01
+    environment:
+      - node.name=es01
+      - cluster.initial_master_nodes=es01
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"
+  adam:
+    build: .
+    depends_on:
+      - "elasticsearch"
+    entrypoint:
+      - bash
+    tty: true

--- a/qas/esstore/es_connect.py
+++ b/qas/esstore/es_connect.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from os.path import isfile
 
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ConnectionError as ESConnectionError
@@ -26,7 +27,10 @@ class ElasticSearchMeta(type):
 
 
 class ElasticSearchConn(metaclass=ElasticSearchMeta):
-    __hostname__ = 'localhost'
+    if isfile('../.dockerenv'):
+        __hostname__ = 'elasticsearch'
+    else:
+        __hostname__ = 'localhost'
     __port__ = 9200
     __es_conn__ = None
     es_index_config = None
@@ -176,8 +180,8 @@ class ElasticSearchConn(metaclass=ElasticSearchMeta):
                             sys.exit(1)
 
                 except ESConnectionError as e:
-                    logger.error("Elasitcsearch is not installed or its service is not running. {0}".format(e))
-                    print("\n -- Elasitcsearch is not installed or its service is not running.--\n", e)
+                    logger.error("Elasticsearch is not installed or its service is not running. {0}".format(e))
+                    print("\n -- Elasticsearch is not installed or its service is not running.--\n", e)
                     sys.exit(1)
             except NewConnectionError:
                 pass


### PR DESCRIPTION
Adam is Dockerized now. A network with Elasticsearch and Adam images is defined in docker-compose.yml, instructions on how to run it are provided in README.md.
qas/esstore/es_connect.py is modified in order to be run both on a local machine or in the container.
Fixes #42